### PR TITLE
Fixed typo in references to smartthings_exporter repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kadaan/smartthingg_exporter
+module github.com/kadaan/smartthings_exporter
 
 go 1.15
 

--- a/smartapps/kadaan/smartthings-exporter-api.src/smartthings-exporter-api.groovy
+++ b/smartapps/kadaan/smartthings-exporter-api.src/smartthings-exporter-api.groovy
@@ -182,11 +182,19 @@ def Map getAttributeMappings() {
                 conversion: this.&valueFloat
             ]
         ],
+        //"Motion Sensor" : [
+        //    "motion" : [
+        //        name: "motion_detection_count",
+        //        type: "counter",
+        //        description: "Count of motion detections.",
+        //        values: ["active"]
+        //    ]
+        //],
         "Motion Sensor" : [
             "motion" : [
-                name: "motion_detection_count",
-                type: "counter",
-                description: "Count of motion detections.",
+                name: "motion_state",
+                type: "gauge",
+                description: "1 if motion detected.",
                 values: ["active"]
             ]
         ],

--- a/smartapps/kadaan/smartthings-exporter-api.src/smartthings-exporter-api.groovy
+++ b/smartapps/kadaan/smartthings-exporter-api.src/smartthings-exporter-api.groovy
@@ -120,6 +120,22 @@ def Map getAttributeMappings() {
                 values: ["open"]
             ]
         ],
+        // "Contact Sensor" : [
+        //    "contact" : [
+        //        name: "contact_opened_count",
+        //        type: "counter",
+        //        description: "Count of times contact was opened.",
+        //        values: ["open"]
+        //    ]
+        //],
+        "Contact Sensor" : [
+            "contact" : [
+                name: "contact_state",
+                type: "gauge",
+                description: "1 if the contact is open.",
+                conversion: this.&valueOpenClose
+            ]
+        ],
         "Energy Meter" : [
             "energy" : [
                 name: "energy_usage_joules",
@@ -323,6 +339,10 @@ private valueOneOf(value, options) {
 
 private valueOnOff(value) {
     return valueOneOf(value, ["off", "on"])
+}
+
+private valueOpenClose(value) {
+    return valueOneOf(value, ["close", "open"])
 }
 
 private valueJoules(value) {

--- a/smartapps/kadaan/smartthings-exporter-api.src/smartthings-exporter-api.groovy
+++ b/smartapps/kadaan/smartthings-exporter-api.src/smartthings-exporter-api.groovy
@@ -195,7 +195,7 @@ def Map getAttributeMappings() {
                 name: "motion_state",
                 type: "gauge",
                 description: "1 if motion detected.",
-                values: ["active"]
+                values: this.&valueOnOff
             ]
         ],
         "Power Meter" : [

--- a/smartthings_exporter.go
+++ b/smartthings_exporter.go
@@ -21,7 +21,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kadaan/smartthingg_exporter/gosmart"
+	"github.com/kadaan/smartthings_exporter/gosmart"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	plog "github.com/prometheus/common/log"


### PR DESCRIPTION
Before fix:
Step 6/8 : RUN go get -d github.com/cengelbracht1/smartthings_exporter
 ---> Running in 13c758a96c25
# cd .; git clone -- https://github.com/kadaan/smartthingg_exporter /go/src/github.com/kadaan/smartthingg_exporter
Cloning into '/go/src/github.com/kadaan/smartthingg_exporter'...
fatal: could not read Username for 'https://github.com': terminal prompts disabled
package github.com/kadaan/smartthingg_exporter/gosmart: exit status 128

After fix:
Step 6/7 : RUN go get -u github.com/cengelbracht1/smartthings_exporter
 ---> Running in e5ed699224bc
Removing intermediate container e5ed699224bc
 ---> 9fd764813a00
Step 7/7 : CMD ["app"]
 ---> Running in 1d1871393e14
Removing intermediate container 1d1871393e14
 ---> cc3737130522
Successfully built cc3737130522
Successfully tagged my-golang-app:latest
